### PR TITLE
Fix finding switch func

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 	verflag.PrintAndExitIfRequested()
 
 	if err := app.Run(s); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%v\n", err) // nolint
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
If you add a tag to the Switch resource from Control Panel,
The Internet(Switch+Router) resource is not tagged.
So this PR fixes function that finds the switch to use the tag of the Switch resource too.