### PR TITLE
Use go 1.13 and alpine 3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: required
 language: go
-go: "1.11"
+go: "1.13"
 services:
 - docker
 install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11 AS builder
+FROM golang:1.13 AS builder
 MAINTAINER Kazumichi Yamamoto <yamamoto.febc@gmail.com>
 LABEL MAINTAINER 'Kazumichi Yamamoto <yamamoto.febc@gmail.com>'
 
@@ -16,7 +16,7 @@ RUN ["make","clean","build"]
 
 #----------
 
-FROM alpine:3.7
+FROM alpine:3.10
 MAINTAINER Kazumichi Yamamoto <yamamoto.febc@gmail.com>
 LABEL MAINTAINER 'Kazumichi Yamamoto <yamamoto.febc@gmail.com>'
 


### PR DESCRIPTION
Note: using alpine 3.10 is temporary. 
The next version of sakura-cloud-controller-manager will use [distroless](https://github.com/GoogleContainerTools/distroless) for base image.